### PR TITLE
Replace "Why (I quit my job)" with "I quit my job"

### DIFF
--- a/Source/content_script.js
+++ b/Source/content_script.js
@@ -26,7 +26,7 @@
 		v = v.replace(/\b[Rr]estored [Oo]ur [Ff]aith [Ii]n [Hh]umanity\b/g, "Affected Us In No Meaningful Way Whatsoever");
 		v = v.replace(/\b(?:Top )?((?:(?:\d+|One|Two|Three|Four|Five|Six|Seven|Eight|Nine|Ten|Eleven|Twelve|Thirteen|Fourteen|Fifteen|Sixteen|Seventeen|Eighteen|Nineteen|Twenty|Thirty|Forty|Fourty|Fifty|Sixty|Seventy|Eighty|Ninety|Hundred)(?: |-)?)+) Weird/g, "$1 Boring");
 		v = v.replace(/\b^(Is|Can|Do|Will) (.*)\?\B/g, "$1 $2? Maybe, but Most Likely Not.");
-		v = v.replace(/\b^(Why\s|How\s)(.*)\b$/g, "$2");
+		v = v.replace(/\b^([Rr]easons\s|[Ww]hy\s|[Hh]ow\s|[Ww]hat\s[Yy]ou\s[Ss]hould\s[Kk]now\s[Aa]bout\s)(.*)\b$/g, "$2");
 			
 		textNode.nodeValue = v;
 	}


### PR DESCRIPTION
Negate effects of headlines that raise inquiry, e.g. "Why I love Slashdot", "How I ate my breakfast this morning", and "What you should know about the recession" to "I love Slashdot" and "I ate my breakfast this morning", more accurately reflecting what the articles are actually about.
- _Reasons_ You Should Eat Vegetables --> You Should Eat Vegetables
- _Why_ I Like Bidets --> I Like Bidets
- _How_ I Saved $0.25 --> I Saved $0.25
- _What You Should Know About_ Headlines --> Headlines
