### PR TITLE
Fixed what I am sure was a very sneaky console.log()

### DIFF
--- a/Source/content_script.js
+++ b/Source/content_script.js
@@ -57,7 +57,6 @@
 
 	chrome.extension.sendRequest({id: 'isPaused?'}, function(response) {
 		var isPaused = response.value;
-		console.log('isPaused is ' + isPaused);
 
 		if(!isPaused) {
 			getDictionary(function() {


### PR DESCRIPTION
Removing the console log because awesome extensions shouldn't be leaking into my console. My poor juniors keep getting yelled at for leaving in `console.log()`s and it's not even their fault.
