### PR TITLE
Additional cleanup to excellent pull request to make simpler

### DIFF
--- a/Source/background.html
+++ b/Source/background.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Background Page</title>
+    <script src="dictionaries/original.js"></script>
     <script src="background.js"></script>
   </head>
   <body>

--- a/Source/background.js
+++ b/Source/background.js
@@ -7,7 +7,6 @@
     var KEY_PAUSED = 'paused';
 
     var _alreadyQueued = false;
-    var _dictionary;
 
     function now() {
         return new Date().getTime();
@@ -39,22 +38,6 @@
                 _alreadyQueued = true;
             }
         }
-    }
-
-    // TODO: Embed a default dictionary in case the JSON doesn't load properly?
-
-    function loadDictionary() {
-        var xhr = new XMLHttpRequest();
-        xhr.onreadystatechange = function() {
-            if(xhr.readyState === 4 && xhr.status === 200) {
-                // eval unfortunately necessary because pure JSON doesn't allow:
-                // comments, question-marks, regular expressions
-                eval("_dictionary = " + xhr.responseText);
-            }
-        };
-        // TODO: Select the JSON file from a value passed into this function.
-        xhr.open("GET", chrome.extension.getURL('dictionaries/original.json'), true);
-        xhr.send();
     }
 
     function updateBadge(paused) {
@@ -103,7 +86,7 @@
             localStorage.setItem(KEY_OPTIONS, request.options);
         }
         else if(requestId == 'getDictionary') {
-            sendResponse(_dictionary);
+            sendResponse(dictionary);
         }
     }
 
@@ -112,7 +95,6 @@
 
     // TODO: Have an option where you can select a specific replacement set, such as "Standard", "Cynical Millenial", etc.
     // TODO: The option value would then be passed into loadDictionary for appropriate dictionary file selection.
-    loadDictionary();
 
     updateBadge(isPaused());
 

--- a/Source/dictionaries/original.js
+++ b/Source/dictionaries/original.js
@@ -1,4 +1,4 @@
-{
+var dictionary={
 	"replacements": {
 		"A Single" : "A",
 		"Absolutely" : "Moderately",
@@ -54,7 +54,7 @@
 		"Will Change Your Life Forever" : "Will Not Change Your Life in ANY Meaningful or Lasting Way",
 		"Won the Internet" : "Seemed Pretty Cool",
 		"Wonderful" : "Mildly Decent",
-		"Worst" : "Vaguely Unpleasantt",
+		"Worst" : "Vaguely Unpleasant",
 		"Wow" : "Oh GOD This is SO Boring. Please Kill Me",
 		"WOW" : "Zzzzzzzzzzz",
 		"You Didn't Know Exist" : "No One Gives a Shit About",
@@ -77,4 +77,4 @@
 		"\\b^(Is|Can|Do|Will) (.*)\\?\\B" : "$1 $2? Maybe, but Most Likely Not.",
 		"\\b^([Rr]easons\\s|[Ww]hy\\s|[Hh]ow\\s|[Ww]hat\\s[Yy]ou\\s[Ss]hould\\s[Kk]now\\s[Aa]bout\\s)(.*)\\b$":"$2"
     }
-}
+};

--- a/Source/manifest.json
+++ b/Source/manifest.json
@@ -33,7 +33,7 @@
     	"default_icon":  "images/icon19-on.png",
 		"default_title": "Toggle Downworthy"
 	},
-  "content_security_policy": "default-src 'none'; script-src 'self' 'unsafe-eval'",
+  "content_security_policy": "default-src 'none'; script-src 'self'",
   "options_page": "options.html"
 	
 }


### PR DESCRIPTION
I just stole @nimishgautam 's pull request, and threw a little bit of simple-juice on it.

Instead of loading the dictionary as JSON, it's now just a JS file. This way you can include comments, etc - as per his suggestion. I think we may also want to be able to use JS Regex literals at some point - though to do that I'd like to change a little about the format of the dictionary file. Maybe for later. Those regex literals would only be valid in JS, not JSON.

I load up the dictionary into the background page, and now a lot of the parsing logic just "goes away".

This also allows us to get rid of "eval" permission.
